### PR TITLE
Change highlighter to use default of rogue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ disqus_username: rimdev
 
 # Build settings
 markdown: kramdown
-highlighter: pygments
 permalink: /:title/
 
 # html minify


### PR DESCRIPTION
The default of `rogue` _just works_ on my machine, whereas `pygments` doesn't seem to _just work_.
