### PR TITLE
Fix Jekyll error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ RIMdev:
     avatar: https://avatars3.githubusercontent.com/u/2921868?v=3&s=460
     twitter:
     github: lightyeare
-   Beth Warner:
+  Beth Warner:
     avatar: https://avatars2.githubusercontent.com/u/1625929?v=3&s=400
     twitter:
     github: bwarner22
@@ -97,7 +97,7 @@ RIMdev:
     twitter: comfroels
     github: comfroels
   Team:
-    avatar: /assets/img/logos/RIMdev-icon-white.svg    
+    avatar: /assets/img/logos/RIMdev-icon-white.svg
 
 nuget:
   - Sandbox


### PR DESCRIPTION
Small change to fix Jekyll.

```
C:\Users\ken.dale\Documents\Projects\ritterim.github.io [master ≡]
λ jekyll doctor
jekyll 3.1.2 | Error:  (C:/Users/ken.dale/Documents/Projects/ritterim.github.io/_config.yml): did not find expected key while parsing a block mapping at line 45 column 3
C:\Users\ken.dale\Documents\Projects\ritterim.github.io [master ≡]
λ git checkout fix-jekyll-issue
Switched to branch 'fix-jekyll-issue'
C:\Users\ken.dale\Documents\Projects\ritterim.github.io [fix-jekyll-issue]
λ jekyll doctor
Configuration file: C:/Users/ken.dale/Documents/Projects/ritterim.github.io/_config.yml
  Your test results are in. Everything looks fine.
```
