### PR TITLE
Improve generation performance by pre-truncating

### DIFF
--- a/_includes/articles-archive.html
+++ b/_includes/articles-archive.html
@@ -33,7 +33,7 @@
             </div><!-- /.time-to-read -->
             </author>
             <p>
-              {{ post.content | markdownify | strip_html | truncate:200 }}
+              {{ post.content | truncate:500 | markdownify | strip_html | truncate:200 }}
             </p>
             <ul class="list-inline">
               {% for tags in post.tags %}

--- a/_includes/articles-sidebar.html
+++ b/_includes/articles-sidebar.html
@@ -19,7 +19,7 @@
         {% endfor %}
       </author>
       <p>
-        {{ post.content | markdownify | strip_html | truncate:120 }}
+        {{ post.content | truncate:500 | markdownify | strip_html | truncate:120 }}
       </p>
       <div class="read-now">
         <a href="{{ post.url | prepend: site.baseurl }}">


### PR DESCRIPTION
This performance optimization is especially nice when you're modifying a post and wishing to see the result reflected in the browser quickly.

Do you think this will cause any issues @hougasian?

![image](https://cloud.githubusercontent.com/assets/1012917/14510165/021cb234-019e-11e6-8f9e-6692c2eb9f7b.png)
