### PR TITLE
Replace markdown-spellcheck with markdown-proofing

### DIFF
--- a/.markdown-proofing
+++ b/.markdown-proofing
@@ -1,0 +1,3 @@
+{
+  "presets": ["technical-blog"]
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Photography by JJ Walck
 
 ## Tests
 
-Tests are ran with `npm test`. Currently, this is a spelling check of posts. This can done interactively as well with `npm run check`.
+Tests are ran with `npm test`. This runs [markdown-proofing](https://www.npmjs.com/package/markdown-proofing) on all posts. See the `scripts` in `package.json` for more runnable commands.
 
 ## New in this release
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "rimdev",
   "version": "1.0.0",
   "description": "The Ritter Insurance Marketing development team blog, hosted at http://rimdev.io/.",
-  "main": "gulpfile.js",
   "scripts": {
-    "check": "mdspell --en-us --ignore-acronyms --ignore-numbers _posts/*.md",
-    "test": "mdspell --en-us --ignore-acronyms --ignore-numbers --report _posts/*.md"
+    "test": "markdown-proofing _posts/*.md",
+    "proof": "markdown-proofing --color --no-throw --",
+    "proof:all": "npm run test -- --no-throw",
+    "proof:latest": "node proofScripts.js latest _posts/*.md",
+    "proof:changed": "node proofScripts.js git-index-and-uncommitted _posts/*.md",
+    "proof:index": "node proofScripts.js git-index _posts/*.md",
+    "proof:uncommitted": "node proofScripts.js git-uncommitted _posts/*.md"
   },
   "keywords": [
     "rimdev",
@@ -13,11 +17,12 @@
   ],
   "author": "rimdev",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/ritterim/ritterim.github.io.git"
+    "type": "git",
+    "url": "https://github.com/ritterim/ritterim.github.io.git"
   },
-  "license": "ISC",
+  "license": "UNLICENSED",
   "devDependencies": {
-    "markdown-spellcheck": "^0.9.0"
+    "markdown-proofing": "latest",
+    "shelljs": "^0.7.0"
   }
 }

--- a/proofScripts.js
+++ b/proofScripts.js
@@ -1,0 +1,80 @@
+require('shelljs/global');
+
+const arg = process.argv[2];
+if (!arg) {
+  echo('Please specify a proofing instruction argument.');
+  exit(1);
+}
+
+const filePattern = process.argv[3];
+if (!filePattern) {
+  echo('Please specify the file pattern as the last argument.');
+  exit(1);
+}
+
+if (arg === 'latest') {
+  const orderedPosts = ls('-l', filePattern)
+    .filter(x => x.name)
+    .map(x => x.name)
+    .sort((a, b) => b.localeCompare(a));
+
+  if (orderedPosts.length > 0) {
+    const latestPost = orderedPosts[0];
+    proof(latestPost);
+  }
+}
+else if (arg === 'git-index') {
+  gitProof(`git diff --name-only --cached ${filePattern}`);
+}
+else if (arg === 'git-uncommitted') {
+  gitProof(`git diff --name-only --diff-filter=ACMRT ${filePattern}`);
+}
+else if (arg === 'git-index-and-uncommitted') {
+  gitProof([
+    `git diff --name-only --diff-filter=ACMRT ${filePattern}`,
+    `git diff --name-only --cached' ${filePattern}`
+  ]);
+}
+
+function gitProof(gitDiffPatterns) {
+  if (!which('git')) {
+    echo('This script requires git.');
+    exit(1);
+  }
+
+  if (!Array.isArray(gitDiffPatterns)) {
+    gitDiffPatterns = [ gitDiffPatterns ];
+  }
+
+  const files = [];
+  gitDiffPatterns.forEach(x => {
+    const gitDiffOutput = exec(x, { silent: true });
+
+    if (gitDiffOutput.stderr) {
+      throw new Error(gitDiffOutput.stderr);
+    }
+
+    if (gitDiffOutput.stdout) {
+      files.push(gitDiffOutput.stdout);
+    }
+  });
+
+  if (files.length === 0) {
+    echo('No files to proof.');
+    exit(0);
+  }
+
+  proof(files);
+}
+
+function proof(files) {
+  if (!Array.isArray(files)) {
+    files = [ files ];
+  }
+
+  const cmd = `npm run proof ${files.join(' ')}`;
+  if (exec(cmd).code !== 0) {
+    echo(`Error while running: ${cmd}`);
+    exit(1);
+  }
+}


### PR DESCRIPTION
Replace the usage of [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) with [markdown-proofing](https://www.npmjs.com/package/markdown-proofing) package.

Benefits:
- The spell check locations should no longer rely on color, making spelling errors possible to determine on TeamCity.
- Additional information is provided as part of the proofing. Currently, this does not introduce any other requirements in order to pass the build.
