### PR TITLE
Run npm install and npm test after Jekyll concerns

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,12 +3,6 @@ pushd %~dp0
 setlocal
 
 :Build
-call npm install
-if %ERRORLEVEL% neq 0 goto BuildFail
-
-call npm test
-if %ERRORLEVEL% neq 0 goto BuildFail
-
 call gem install bundler
 if %ERRORLEVEL% neq 0 goto BuildFail
 
@@ -16,6 +10,12 @@ call bundle install
 if %ERRORLEVEL% neq 0 goto BuildFail
 
 call bundle exec jekyll build
+if %ERRORLEVEL% neq 0 goto BuildFail
+
+call npm install
+if %ERRORLEVEL% neq 0 goto BuildFail
+
+call npm test
 if %ERRORLEVEL% neq 0 goto BuildFail
 
 goto BuildSuccess


### PR DESCRIPTION
Reorder the build script to run `npm install` and `npm test` after Jekyll concerns.
