### PR TITLE
Remove npm test from build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -15,9 +15,6 @@ if %ERRORLEVEL% neq 0 goto BuildFail
 call npm install
 if %ERRORLEVEL% neq 0 goto BuildFail
 
-call npm test
-if %ERRORLEVEL% neq 0 goto BuildFail
-
 goto BuildSuccess
 
 :BuildFail


### PR DESCRIPTION
Seems to be more of a burden than help. It is still part of the solution and can be run by the author.
