### PR TITLE
Disable spell check

### DIFF
--- a/.markdown-proofing
+++ b/.markdown-proofing
@@ -1,3 +1,6 @@
 {
-  "presets": ["technical-blog"]
+  "presets": ["technical-blog"],
+  "rules": {
+    "spelling-error": "info"
+  }
 }


### PR DESCRIPTION
Not sure how to just turn-off spell check, so used technical-blog as template for markdown-proofing settings.
