### PR TITLE
Add external_links_target_blank configuration to posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
     </div>
     <!-- main post column -->
     <div class="col col-md-12 col-lg-8 col-xl-9">
-      <div class="post-main-column">
+      <div class="post-main-column" id="post-main-column-js" {% if page.external_links_target_blank %} data-external-links-target-blank="true" {% endif %}>
       {{ content }}
       </div>
     </div>

--- a/_posts/2016-09-16-under-the-decision-tree-1.md
+++ b/_posts/2016-09-16-under-the-decision-tree-1.md
@@ -2,12 +2,13 @@
 layout: post
 title: "Under the Decision Tree (#1)"
 date: 2016-09-16 11:00:00
-tags: 
+tags:
 - Machine Learning
 categories: Under the Decision Tree
 twitter_text: Under the Decision Tree (#1)
 authors: Scott Schwalm
 image: /images/tree-338211_1280.jpg
+external_links_target_blank: true
 ---
 
 Welcome to the first post in what will be a weekly series we are calling **Under the Decision Tree**.  This will be a listing of blog posts, podcasts, news articles, and anything else we found interesting in the world of machine learning during the past week.

--- a/js/main.js
+++ b/js/main.js
@@ -53,4 +53,11 @@
       $(this).removeClass("hover-out").dequeue();
     });
   });
+
+  var $postMainColumnJs = $('#post-main-column-js');
+  if ($postMainColumnJs.data('external-links-target-blank')) {
+
+    // Selector from http://stackoverflow.com/a/1871394 from http://stackoverflow.com/questions/1871371/using-jquery-to-open-all-external-links-in-a-new-window
+    $postMainColumnJs.find("a[href^='http://']").prop('target', '_blank');
+  }
 })(jQuery);


### PR DESCRIPTION
Add `external_links_target_blank` configuration to posts. I set it to `true` on `_posts/2016-09-16-under-the-decision-tree-1.md` in this PR.

**Note:** This does not include any visual indication to the user.
