### PR TITLE
Update Bootstrap to alpha.4, use suggested CDN loaded JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tests are ran with `npm test`. This runs [markdown-proofing](https://www.npmjs.c
 ## New in this release
 
 - Jekyll 3 ([faster](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0), [release notes](https://jekyllrb.com/news/2015/10/26/jekyll-3-0-released/))
-- [Bootstrap 4 (Alpha 2)](http://v4-alpha.getbootstrap.com/getting-started/introduction/)
+- [Bootstrap 4 (Alpha 4)](http://v4-alpha.getbootstrap.com/getting-started/introduction/)
 - [Jekyll @mentions](https://github.com/jekyll/jekyll-mentions)
 - [Jekyll gist](https://github.com/jekyll/jekyll-gist) support
 - author pages (see below)
@@ -89,7 +89,7 @@ Using a Creative Commons image requiring attribution?
 image: https://farm5.staticflickr.com/4103/5029857600_d8ed3aaa06_b_d.jpg
 image_url: https://www.flickr.com/photos/khawkins04/
 image_credit: Ken Hawkins
-```  
+```
 
 ### Author pages
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.description }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link href="https://fonts.googleapis.com/css?family=Work+Sans:300|Roboto+Slab:400,300,100" rel="stylesheet" type="text/css">
-  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" rel="stylesheet" integrity="sha256-xWeRKjzyg6bep9D1AsHzUPEWHbWMzlRc84Z0aG+tyms= sha512-mGIRU0bcPaVjr7BceESkC37zD6sEccxE+RJyQABbbKNe83Y68+PyPM5nrE1zvbQZkSHDCJEtnAcodbhlq2/EkQ==" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css" integrity="sha384-2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/{{ site.fa_version }}/css/font-awesome.min.css">
 
   <link rel="stylesheet" href="/css/main.css">

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,3 +1,4 @@
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha256-GMscmjNs6MbZvXG2HRjP3MpdOGmXv078SRgH7M723Mc= sha512-1wnhBRtA+POGVA0yREk2RlDbJEdkNvMuRBGjT1FCI5wXmpiQHZWDIB8MpANBWM/GKSPDgCA/7HTrAIFgv70/Jw==" crossorigin="anonymous"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js" integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU" crossorigin="anonymous"></script>
 <script src="/js/main.js"></script>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -34,7 +34,7 @@ body {
     a {font-size: 1em;}
   }
   ol li {margin-bottom: 1em;}
-  // strong {font-weight: bolder;}
+  strong {font-weight: bold;}
   .container-fluid {
     padding: 0;
   }


### PR DESCRIPTION
This fixes `Uncaught Error: Bootstrap tooltips require Tether (http://github.hubspot.com/tether/)`, too.

Here's a difference:

![image](https://cloud.githubusercontent.com/assets/1012917/18757507/3299d75e-80c2-11e6-93d1-8c6c7bd96a33.png)
