### PR TITLE
Allow trailing whitespace in markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
In `.editorconfig`, allow the usage of line breaks in `.md` files via trailing spaces.
