### PR TITLE
[Spike] url shortener via Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ rim_url: https://ritterim.com
 rim_blog: https://blog.ritterim.com
 map_url: https://www.google.com/maps/place/2600+Commerce+Dr,+Harrisburg,+PA+17110/@40.311295,-76.843902,14z/data=!4m2!3m1!1s0x89c8c76c07f542d5:0xa2d30cdf7911f0fa?hl=en
 default_image: /images/default/rimdev-surface.jpg
+safe: false
 
 # Font Awesome version
 fa_version: 4.5.0
@@ -43,6 +44,12 @@ disqus_username: rimdev
 
 # exclude my node related stuff
 exclude: ['package.json', 'src', 'node_modules']
+
+# Url Shortener
+shortener:
+  basepath: /s/        # Path for stored redirects.
+  preserve: false      # Keep previously generated files.
+  salt:     "RimDev"   # The optional salt, used when hasing the Unix time.
 
 # RIMdev posting authors
 RIMdev:

--- a/_includes/share.html
+++ b/_includes/share.html
@@ -1,13 +1,17 @@
+{% capture social_url %}{{site.url}}{{page.url}}{% endcapture %}
+{%if page.short %}
+  {% assign social_url = page.short.url %}
+{% endif %}
 <ul class="list-inline share">
   <li class="list-inline-item">Share</li>
   <li class="list-inline-item">
-    <a href="https://twitter.com/intent/tweet?text=&quot;{{ page.twitter_text | url_encode }}&quot;%20{{ site.url }}{{ page.url }}%20via%20&#64;{{ site.twitter_username }}"
+    <a href="https://twitter.com/intent/tweet?text=&quot;{{ page.twitter_text | url_encode }}&quot;%20{{ social_url }}"
     onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;" title="Share on Twitter">
     <i class="fa fa-twitter"></i>
     </a>
   </li>
   <li class="list-inline-item">
-    <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}"
+    <a href="https://plus.google.com/share?url={{ social_url }}"
     onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;" title="Share on Google+">
     <i class="fa fa-google-plus"></i>
     </a>

--- a/_plugins/url-shortener.rb
+++ b/_plugins/url-shortener.rb
@@ -1,0 +1,87 @@
+# Short URL generator for posts.
+#
+# Generates shortened URL pages based on the SHA1 hash of the post date.
+#
+# Example post configuration:
+#
+#    ---
+#     layout:  post
+#     title:   "URL Shortener for Jekyll."
+#     date:    1970-01-01 00:00:00           # The timestamp is converted to Unix time.
+#     shorten: true                          # Shorten this post.
+#    ---
+#
+# Exmaple _config.yml configuration:
+#
+#    shortener:
+#       basepath: /s/        # Path for stored redirects.
+#       preserve: false      # Keep previously generated files.
+#       salt:     "LouisT"   # The optional salt, used when hasing the Unix time.
+#
+# Author: Louis T.
+# Site: https://lou.ist/
+# Plugin Source: http://github.com/LouisT/jekyll-url-shortener
+# Plugin License: MIT
+require 'digest/sha1'
+
+module Jekyll
+  class ShortenedFile < StaticFile
+    def write (dest)
+      super(dest) rescue ArgumentError
+      true
+    end
+  end
+  class URLShortener < Generator
+    safe true
+    priority :low
+    def generate (site)
+        @site = site
+
+        baseurl = site.config['baseurl'] ? site.config['baseurl'] : ''
+        weburl = site.config['url'] ? site.config['url'] : ''
+        shortpath = site.config['shortener']['shortpath'] ? site.config['shortener']['shortpath'] : '/s/'
+        salt = site.config['shortener']['salt'] ? site.config['shortener']['salt'] : ''
+        @site.posts.docs.each do |post|
+          if post.data['shorten'] and post.data['date']
+             hash = Digest::SHA1.new.hexdigest(post.data['date'].to_i.to_s + salt.to_s)[0...10]
+             path = File.join(baseurl, shortpath, hash)
+             dest = File.join(site.dest, path)
+             file = File.join(dest, 'index.html')
+             post.data['short'] = {
+               "url" => weburl+path,
+               "hash" => hash
+             }
+             unless File.directory?(dest)
+                FileUtils.mkdir_p(dest)
+              else
+                if site.config['shortener']['preserve']
+                   return site.static_files << ShortenedFile.new(site, dest, '/', file)
+                end
+             end
+             File.open(file, 'w') do |file|
+               file.write(template(post.url, post.data['title']).gsub(/\n\s+/, " ").strip)
+               file.close
+             end
+             site.static_files << ShortenedFile.new(site, dest, '/', file)
+          end
+        end
+    end
+    def template (redirect, title)
+        <<-EOF
+        <!DOCTYPE html>
+        <html>
+         <head>
+          <title>#{title}</title>
+          <link rel="canonical" href="#{redirect}"/>
+          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="refresh" content="0; url = #{redirect}" />
+         </head>
+         <body>
+          <h3><a href="#{redirect}">#{redirect}</a></h3>
+          <script>window.location = "#{redirect}"</script>
+         </body>
+        </html>
+        EOF
+    end
+  end
+end

--- a/_posts/2016-10-28-under-the-decision-tree-5.md
+++ b/_posts/2016-10-28-under-the-decision-tree-5.md
@@ -9,6 +9,7 @@ twitter_text: "Under the Decision Tree (#5) #machinelearning #AI #artificialinte
 authors: Scott Schwalm
 image: /images/tree-338211_1280.jpg
 external_links_target_blank: true
+shorten: true
 ---
 
 Welcome back for another edition of **Under the Decision Tree**.  We had a small break since the last episode.  So there are quite a few interesting artices and podcasts to catch up on.


### PR DESCRIPTION
This uses the plugin https://github.com/LouisT/jekyll-url-shortener. 

A few things to note:

- Not sure if `_plugins` work on GitHub pages
- The redirect happens via an HTML generated file
- `shorten` is an opt-in feature

It works locally and liquid is a total PITA.

> "Under the Decision Tree (#5) #machinelearning #AI #artificialintelligence #software #bigdata #science" http://rimdev.io/s/3f6640a2b4

@hougasian @brenthack35 