### PR TITLE
Add word-break: break-all; to related articles

### DIFF
--- a/_sass/_articles-related.scss
+++ b/_sass/_articles-related.scss
@@ -14,6 +14,7 @@
   .description {
     line-height: 1.2em;
     font-size: 95%;
+    word-break: break-all;
   }
   .content {
     .read-now {


### PR DESCRIPTION
Addresses this issue with content leaving the expected area:

![image](https://cloud.githubusercontent.com/assets/1012917/20325128/50f06b14-ab51-11e6-8538-81578623a4f8.png)
