### PR TITLE
Rename gems to plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ kramdown:
 
 # Plugins
 # sitemap: false in front matter of page to exclude
-gems:
+plugins:
   - jekyll-mentions
   - jekyll-redirect-from
   - jekyll-seo-tag


### PR DESCRIPTION
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```