### PR TITLE
Remove Jekyll-Feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,6 @@ plugins:
   - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-sitemap
-  - jekyll-feed
 
 # will convert @twitter-handle to the full twitter link in a post
 jekyll-mentions: https://twitter.com

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,35 @@
+---
+layout: null
+permalink: feed.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<generator uri="http://jekyllrb.com" version="{{ jekyll.version }}">Jekyll</generator>
+<link href="{{ site.feed.path | prepend: '/' | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/atom+xml"/>
+<link href="{{ site.url }}/" rel="alternate" type="text/html"/>
+<updated>{{ site.time | date_to_xmlschema }}</updated>
+<id>{{ site.url }}/</id>
+<title>{{ site.title | xml_escape }}</title>
+<subtitle>{{ site.description | xml_escape }}</subtitle>
+{% for post in site.posts limit:10 %}
+<entry>
+<title>{{ post.title | xml_escape }}</title>
+<link href="{{ post.url | prepend: site.baseurl | prepend: site.url }}" rel="alternate" type="text/html" title="{{ post.title }}"/>
+<published>{{ post.date | date_to_xmlschema }}</published>
+<updated>{{ post.date | date_to_xmlschema }}</updated>
+<id>{{ post.url | remove: '.html' | prepend: site.baseurl | prepend: site.url }}</id>
+<content type="html" xml:base="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.content | xml_escape }}</content>
+<author>
+<name>{{post.author}}</name>
+</author>
+<summary>{{ post.excerpt | strip_html | xml_escape }}</summary>
+{% for tag in post.tags %}
+<category term="{{ tag | xml_escape }}"/>
+{% endfor %}
+{% for cat in post.categories %}
+<category term="{{ cat | xml_escape }}"/>
+{% endfor %}
+</entry>
+
+{% endfor %}
+</feed>


### PR DESCRIPTION
This just uses a feed.xml at the root of the site instead
of jekyll-feed, which seems to generate an invalid feed.xml file.

This fixes validation of our feed against the W3C validator.