### PR TITLE
Fix JS syntax in post

### DIFF
--- a/_posts/2018-10-08-post-javascript-object-cloning.md
+++ b/_posts/2018-10-08-post-javascript-object-cloning.md
@@ -16,7 +16,7 @@ In JavaScript, we are always working with different data types to send to the AP
 
 ```javascript
 let originalArray = [1,2,3,4];
-let newArray = originalArray;
+let newArray = originalArray.slice();
 newArray.push(5);
 
 console.log(originalArray);
@@ -61,7 +61,7 @@ Now if we create a new array called `filteredList` by just assigning it from `cl
 
 
 ```javascript
-let filteredList = clientList;
+let filteredList = clientList.slice();
 
 filteredList[0].firstName= "Billy";
 


### PR DESCRIPTION
Previous behavior assigned reference of original array to new array. This affected the demo. since adding a value-type to the "new" array also adds it to the "original" array.

New behavior creates a new array, but still makes a shallow copy of data, so the example related to objects still reinforces the idea of "pass-by-ref".