### PR TITLE
bug: get rid of pipe character

### DIFF
--- a/_posts/2020-09-22-vue-3-is-official.md
+++ b/_posts/2020-09-22-vue-3-is-official.md
@@ -55,4 +55,4 @@ I am excited about the release of Vue 3! The changes that were made will make le
 - [vue 3 source code](https://github.com/vuejs/vue-next/releases/tag/v3.0.0)
 - [Evan You Vue 3 announcement at Vuejs Global](https://www.youtube.com/watch?v=Vp5ANvd88x0&t)
 - [Natalia Tepluhina // Migrating a big old codebase to Vue 3: what I'm excited about at Vuejs Global](https://www.youtube.com/watch?v=K1JoWmXh4qA&t)
-- [What you'll love in Vue 3 by Alex Kyriakidis | VueConf US 2020](https://www.youtube.com/watch?v=feSVHEQ8ik4)
+- [What you'll love in Vue 3 by Alex Kyriakidis](https://www.youtube.com/watch?v=feSVHEQ8ik4)


### PR DESCRIPTION
This gets rid of the | causing a problem with the markdown creating link in my blog post

![Screen Shot 2020-10-12 at 2 06 36 PM](https://user-images.githubusercontent.com/21014591/95777442-2fb4c000-0c94-11eb-8e58-73e6d7fb560e.png)
